### PR TITLE
Fixed computation of sinThetaO for 'velvety' BRDF

### DIFF
--- a/devices/device_ispc/brdfs/velvety.isph
+++ b/devices/device_ispc/brdfs/velvety.isph
@@ -77,7 +77,7 @@ vec3f varying_Velvety__eval(const uniform BRDF* uniform _this,
   const varying Velvety* uniform this = (const varying Velvety* uniform) _this;
   const float cosThetaO = clamp(dot(wo,dg.Ns));
   const float cosThetaI = clamp(dot(wi,dg.Ns));
-  const float sinThetaO = sqrt(1.0f - cosThetaO);
+  const float sinThetaO = sqrt(1.0f - cosThetaO * cosThetaO);
   const float horizonScatter = pow(sinThetaO, this->f);
   return mul(horizonScatter * cosThetaI * one_over_pi, this->R);
 }


### PR DESCRIPTION
This looks like a simple error, although the origin of this BRDF is unclear. Perhaps this could be documented?
