### PR TITLE
suppress icc warnings when building with ispc 'generic-knc/knl' support

### DIFF
--- a/common/cmake/icc_mic.cmake
+++ b/common/cmake/icc_mic.cmake
@@ -20,7 +20,7 @@ SET(__SSE__ 0)
 SET(__AVX__ 0)
 
 SET (CMAKE_CXX_COMPILER icpc)
-SET (CMAKE_CXX_FLAGS "-mmic -restrict -Wall -fasm-blocks -fPIC")
+SET (CMAKE_CXX_FLAGS "-mmic -restrict -Wall -wd177 -fasm-blocks -fPIC")
 SET (CMAKE_CXX_FLAGS_NOOPT "-O0 -DDEBUG")
 SET (CMAKE_CXX_FLAGS_DEBUG "-g -w1 -O2 -DDEBUG ")
 


### PR DESCRIPTION
When generating '.cpp' files in generic mode for KNL/KNC support, the latest version of ISPC generates unused '::init' functions for structure initialization. This produces ~11MB of warnings upon embree-renderer build. This commit adds a flag to suppress those warnings.