### PR TITLE
Write fullpath of source files in tlog

### DIFF
--- a/common/cmake/ispc.targets
+++ b/common/cmake/ispc.targets
@@ -32,7 +32,7 @@
       <ISPC_tlog
         Include="%(ISPC.Outputs)"
         Condition="'%(ISPC.Outputs)' != '' and '%(ISPC.ExcludedFromBuild)' != 'true'">
-        <Source>@(ISPC, '|')</Source>
+        <Source>@(ISPC-&gt;'%(Fullpath)', '|')</Source>
       </ISPC_tlog>
     </ItemGroup>
     <Message
@@ -40,7 +40,7 @@
       Text="%(ISPC.ExecutionDescription)" />
     <WriteLinesToFile
       Condition="'@(ISPC_tlog)' != '' and '%(ISPC_tlog.ExcludedFromBuild)' != 'true'"
-      File="$(IntDir)$(ProjectName).write.1.tlog"
+      File="$(IntDir)$(ProjectName).tlog\ISPC.write.1.tlog"
       Lines="^%(ISPC_tlog.Source);@(ISPC_tlog-&gt;'%(Fullpath)')" />
     <ISPC
       Condition="'@(ISPC)' != '' and '%(ISPC.ExcludedFromBuild)' != 'true'"


### PR DESCRIPTION
The "tlog" (tracking log) files in Visual Studio are used by MSBuild to figure out when a file should be recompiled.

For example, an fxc.write.1.tlog file (created by the FXC HLSL shader compiler) might have the following contents:

    ^C:\myproject\myshader.hlsl
    C:\myproject\myshader.cso

This indicates that the source file hlsl writes the cso file as output. Therefore, if the source file has a newer timestamp than the output file, that means the source file should be rebuilt.

Turns out, as far as I can tell in my experiments, these paths MUST be absolute paths, not relative paths. If the path is relative, the dependency between files will not work. This ispc.targets file used to write an absolute path for the output file, but used a relative path for the source file. Therefore, I made the following change:

    remove: <Source>@(ISPC, '|')</Source>
    add: <Source>@(ISPC-&gt;'%(Fullpath)', '|')</Source>

The old version used a relative path, and the new version uses an absolute path, as seemingly required for correct behavior.

Furthermore, this script used to write into `$(IntDir)$(ProjectName).write.1.tlog`. This goes against the conventions of tlog files, which are normally stored in the `$(IntDir)$(ProjectName).tlog` folder (a subfolder of the intermediate directory). For this reason, I also changed the directory of the file being written to `$(IntDir)$(ProjectName).tlog\ISPC.write.1.tlog`.

Ideally, this ispc.targets file should not be writing the tlog files. Instead, the tlog file should be written by the execution of ispc.exe itself, with a hook in the Windows OS call `CreateFile` so that it automatically writes tlog files based on which files are read and written by the compilation. This is important to do right, since otherwise the build system will not realize that included files are out of date, or that files should be rebuilt if you modify the ispc.exe used to compile the files. If we want to do this, that would be a separate future patch.