### PR TITLE
fix tlog folder name

### DIFF
--- a/common/cmake/ispc.targets
+++ b/common/cmake/ispc.targets
@@ -40,7 +40,7 @@
       Text="%(ISPC.ExecutionDescription)" />
     <WriteLinesToFile
       Condition="'@(ISPC_tlog)' != '' and '%(ISPC_tlog.ExcludedFromBuild)' != 'true'"
-      File="$(IntDir)$(ProjectName).tlog\ISPC.write.1.tlog"
+      File="$(TLogLocation)ISPC.write.1.tlog"
       Lines="^%(ISPC_tlog.Source);@(ISPC_tlog-&gt;'%(Fullpath)')" />
     <ISPC
       Condition="'@(ISPC)' != '' and '%(ISPC.ExcludedFromBuild)' != 'true'"


### PR DESCRIPTION
Turns out that if your Visual Studio project name is too long, the tlog
folder stops being your project name, and instead becomes half project
name half random GUID. This commit uses the proper MSBuild variable
`TLogLocation`, which is robust to these changes of tlog folder name.